### PR TITLE
Fix MaxWait only configuration

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -85,7 +85,7 @@ func (p *BatchProducer) WatchProducer() {
 		case <-time.After(p.MaxWait):
 			p.Log.Infoln("MaxWait", "Items=", len(items))
 			if len(items) == 0 {
-				return
+				continue
 			}
 			
 			items = p.releaseBatch(items)


### PR DESCRIPTION
Don't quit when no Items are present after MaxWait passes. Instead, continue and wait for MaxItems or MaxWait to be reached again.