### PR TITLE
Make log level configurable

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -95,11 +95,6 @@ func (b *Batch) ReadItems() {
 	}
 }
 
-// SetLogLevel [Info:Debug]
-func (b *Batch) SetDebugLogLevel() {
-	b.Log.SetLogLevel(log.Debug)
-}
-
 // StopProducer to exit the Producer line.
 func (b *Batch) StopProducer() {
 	b.Producer.Quit <- true
@@ -121,7 +116,7 @@ func (b *Batch) Close() {
 
 	select {
 	case <-done:
-		b.Log.Warn("Done")
+		b.Log.Info("Done")
 		b.Semaphore.Lock()
 		b.Stop()
 		close(b.Item)

--- a/example/main.go
+++ b/example/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	log "github.com/sirupsen/logrus"
-	batch "github.com/Deeptiman/go-batch"
+	batch "github.com/wlach/go-batch"
+	batchLog "github.com/wlach/go-batch/logger"
 )
 
 // Resources Structure
@@ -22,9 +24,9 @@ func main() {
 	debugFlag := flag.Bool("d", false, "Debug mode")
 	flag.Parse()
 
-	logLevel := log.InfoLevel
+	logLevel := batchLog.Info
 	if *debugFlag {
-		logLevel = log.DebugLevel
+		logLevel = batchLog.Debug
 	}
 
 	logs := log.New()

--- a/example/main.go
+++ b/example/main.go
@@ -19,13 +19,19 @@ func main() {
 	var rFlag, mFlag int
 	flag.IntVar(&rFlag, "r", 10, "No of resources")
 	flag.IntVar(&mFlag, "m", 10, "Maximum items")
+	debugFlag := flag.Bool("d", false, "Debug mode")
 	flag.Parse()
+
+	logLevel := log.InfoLevel
+	if *debugFlag {
+		logLevel = log.DebugLevel
+	}
 
 	logs := log.New()
 
 	logs.Infoln("Batch Processing Example !")
 
-	b := batch.NewBatch(batch.WithMaxItems(uint64(mFlag)))
+	b := batch.NewBatch(batch.WithMaxItems(uint64(mFlag)), batch.WithLogLevel(logLevel))
 
 	b.StartBatchProcessing()
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,7 +7,8 @@ import (
 type LogLevel int
 
 const (
-	Info   LogLevel = iota
+	Error LogLevel = iota
+	Info
 	Debug		
 )
 
@@ -25,6 +26,8 @@ func NewLogger() *Logger {
 		TimestampFormat: "2006-01-02 15:04:05",
 		FullTimestamp:   true,
 	})
+	// only log errors by default
+	log.SetLevel(logrus.ErrorLevel)
 
 	return &Logger{
 		log: log,
@@ -34,6 +37,10 @@ func NewLogger() *Logger {
 func (l *Logger) SetLogLevel(level LogLevel) {
 	if level == Debug {
 		l.log.Level = logrus.DebugLevel
+	} else if level == Info {
+		l.log.Level = logrus.InfoLevel
+	} else {
+		l.log.Level = logrus.ErrorLevel
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package batch
 
-import "time"
+import (
+	"time"
+
+	log "github.com/Deeptiman/go-batch/logger"
+)
 
 type BatchOptions func(b *BatchProducer)
 
@@ -13,5 +17,11 @@ func WithMaxItems(maxItems uint64) BatchOptions {
 func WithMaxWait(maxWait time.Duration) BatchOptions {
 	return func(b *BatchProducer) {
 		b.MaxWait = maxWait
+	}
+}
+
+func WithLogLevel(level log.LogLevel) BatchOptions {
+	return func(b *BatchProducer) {
+		b.Log.SetLogLevel(level)
 	}
 }

--- a/producer.go
+++ b/producer.go
@@ -72,25 +72,25 @@ func (p *BatchProducer) WatchProducer() {
 		case item := <-p.Watcher:
 
 			item.BatchNo = int(p.getBatchNo())
-			p.Log.Debugln("BatchProducer", "Id=", item.Id, "Batch Break=", item.Id / int(p.MaxItems), "BatchNo=",item.BatchNo, "Item=", item.Item)
+			p.Log.Debugln("BatchProducer", "Id=", item.Id, "Batch Break=", item.Id/int(p.MaxItems), "BatchNo=", item.BatchNo, "Item=", item.Item)
 
-			items = append(items, *item)			
-			
+			items = append(items, *item)
+
 			if (item.Id / int(p.MaxItems)) == item.BatchNo {
 				p.Log.Infoln("BatchReady", "BatchNo=", item.BatchNo)
 				items = p.releaseBatch(items)
 				p.createBatchNo()
 			}
-			
+
 		case <-time.After(p.MaxWait):
 			p.Log.Infoln("MaxWait", "Items=", len(items))
 			if len(items) == 0 {
 				continue
 			}
-			
+
 			items = p.releaseBatch(items)
 		case <-p.Quit:
-			p.Log.Warn("Quit BatchProducer")
+			p.Log.Info("Quit BatchProducer")
 
 			return
 		}


### PR DESCRIPTION
As things stand, we log very verbosely to standard out even where
that doesn't make sense (e.g. in a production context).
